### PR TITLE
Add JSON export and clustering to detect_faces_simple

### DIFF
--- a/scripts/detect_faces_simple.py
+++ b/scripts/detect_faces_simple.py
@@ -1,6 +1,8 @@
 import argparse
+from dataclasses import asdict
 from pathlib import Path
 from typing import List, Optional
+import json
 
 import torchvision
 
@@ -20,7 +22,9 @@ def load_config() -> OmegaConf:
     the pre-generated configuration found under ``conf/merged``.
     """
 
-    config_file = Path(__file__).resolve().parents[1] / "conf" / "merged" / "merged.config.yaml"
+    config_file = (
+        Path(__file__).resolve().parents[1] / "conf" / "merged" / "merged.config.yaml"
+    )
     return OmegaConf.load(config_file)
 
 
@@ -30,6 +34,7 @@ def detect_faces(
     verbose: bool = False,
     compare: bool = False,
     montage_path: Optional[str] = None,
+    json_path: Optional[str] = None,
 ) -> None:
     """Run face detection on a single image.
 
@@ -41,6 +46,8 @@ def detect_faces(
         Where the resulting image with drawn detections is saved.
     montage_path: Optional[str]
         If provided, saves a thumbnail montage of all detected faces to this path.
+    json_path: Optional[str]
+        Path to save the detected face information as JSON.
     """
     cfg = load_config()
     analyzer = FaceAnalyzer(cfg.analyzer)
@@ -52,23 +59,72 @@ def detect_faces(
         include_tensors=cfg.include_tensors,
         path_output=output_path,
     )
+    if response.img.nelement() > 0:
+        img = torchvision.transforms.functional.to_pil_image(response.img.cpu())
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        img.save(output_path)
     if verbose:
         print(response)
 
-    if compare and len(response.faces) > 1:
-        embeds: List[torch.Tensor] = []
-        for face in response.faces:
-            if "embed" in face.preds:
-                embeds.append(face.preds["embed"].logits)
+    embeds: List[torch.Tensor] = [
+        face.preds["embed"].logits for face in response.faces if "embed" in face.preds
+    ]
 
-        if len(embeds) > 1:
-            embed_tensor = torch.stack(embeds)
-            dists = torch.cdist(embed_tensor, embed_tensor)
-            print("Pairwise embedding distances:")
-            for row in dists:
-                print(" ".join(f"{val:.4f}" for val in row.tolist()))
-        else:
-            print("No embeddings available for comparison")
+    if compare and len(embeds) > 1:
+        embed_tensor = torch.stack(embeds)
+        dists = torch.cdist(embed_tensor, embed_tensor)
+        print("Pairwise embedding distances:")
+        for row in dists:
+            print(" ".join(f"{val:.4f}" for val in row.tolist()))
+    elif compare:
+        print("No embeddings available for comparison")
+
+    clusters = []
+    if len(embeds) > 1:
+        embed_tensor = torch.stack(embeds)
+        dists = torch.cdist(embed_tensor, embed_tensor)
+        threshold = 0.6
+        adjacency = (dists < threshold).cpu().numpy()
+        visited = set()
+        for i in range(len(embeds)):
+            if i in visited:
+                continue
+            stack = [i]
+            cluster = []
+            while stack:
+                j = stack.pop()
+                if j in visited:
+                    continue
+                visited.add(j)
+                cluster.append(j)
+                neighbors = [
+                    k
+                    for k in range(len(embeds))
+                    if adjacency[j, k] and k not in visited
+                ]
+                stack.extend(neighbors)
+            clusters.append(cluster)
+        print("Clusters (threshold=0.6):")
+        for idx, c in enumerate(clusters):
+            print(f"  Cluster {idx}: {c}")
+
+    if json_path:
+
+        def serialize(obj):
+            if isinstance(obj, torch.Tensor):
+                return obj.tolist()
+            elif isinstance(obj, dict):
+                return {k: serialize(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [serialize(v) for v in obj]
+            else:
+                return obj
+
+        faces_data = [serialize(asdict(face)) for face in response.faces]
+        out = {"faces": faces_data, "clusters": clusters}
+        Path(json_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(json_path, "w") as f:
+            json.dump(out, f, indent=2)
 
     if montage_path and len(response.faces) > 0:
         face_tensors = [
@@ -115,6 +171,12 @@ if __name__ == "__main__":
         default="data/output/montage.png",
         help="Path for saving the montage of detected faces",
     )
+    parser.add_argument(
+        "--json",
+        "-j",
+        default="data/output/faces.json",
+        help="Path for saving detected faces information as JSON",
+    )
     args = parser.parse_args()
     detect_faces(
         args.image,
@@ -122,4 +184,5 @@ if __name__ == "__main__":
         verbose=args.verbose,
         compare=args.compare,
         montage_path=args.montage,
+        json_path=args.json,
     )


### PR DESCRIPTION
## Summary
- enhance `detect_faces_simple.py` to always save the output image
- add option to dump faces as JSON
- compute simple clustering of embeddings
- allow custom JSON output path via CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6856a87f228c832e929b7186ae435411