### PR TITLE
Fix indentation in detect_faces_simple.py

### DIFF
--- a/scripts/detect_faces_simple.py
+++ b/scripts/detect_faces_simple.py
@@ -37,7 +37,7 @@ def detect_faces(
     montage_path: Optional[str] = None,
     json_path: Optional[str] = None,
 ) -> None:
-"""Run face detection on a single image or all images in a folder.
+    """Run face detection on a single image or all images in a folder.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- fix incorrect indentation in `detect_faces_simple.py`

## Testing
- `python -m py_compile scripts/detect_faces_simple.py`
- `pytest tests/test_reader.py::test_base_type -q` *(fails: `ModuleNotFoundError: No module named 'facetorch'`)*

------
https://chatgpt.com/codex/tasks/task_e_68578930e2ec832ea90ad56e2697af6e