### PR TITLE
Add setup.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ pip install facetorch
 ```bash
 conda install -c conda-forge facetorch
 ```
+For a development setup clone this repository and run:
+```bash
+./setup.sh
+```
 ## Usage
 
 ### Prerequisites

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# Update pip
+python -m pip install --upgrade pip
+
+# Install library with requirements from environment.yml
+pip install -e .
+
+# Install development requirements if present
+if [ -f requirements.dev.txt ]; then
+    pip install -r requirements.dev.txt
+fi


### PR DESCRIPTION
## Summary
- add setup.sh helper for pip installation
- reference setup.sh in README

## Testing
- `bash setup.sh`
- `pytest -q` *(fails: Could not read image from path)*

------
https://chatgpt.com/codex/tasks/task_e_685788b52950832e8fb311e68f3ae96b